### PR TITLE
Added Hover Style

### DIFF
--- a/assets/css/form.css
+++ b/assets/css/form.css
@@ -130,6 +130,8 @@
 		padding-bottom: 0.75em;
 		text-decoration: none;
 	}
+
+	
 	li input[type="checkbox"] {
 		font-size: inherit;
 	}
@@ -177,3 +179,10 @@
 		border-color: rgb(40, 137, 187); /* @blueberry */
 	}
 
+	@media (min-width:1025px) { 
+		
+		li label:hover{
+			background-color: #b3b3b3;	
+		}
+	}
+	


### PR DESCRIPTION
Added Hover Style to the Search page list item labels, the hover effects makes the page feel a bit more responsive. Without it, it didnt feel as apparent what the lis were actually doing. That being said, on mobile it looks tacky, so a media query may be best here